### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A server built using Model-Context Protocol (MCP) that provides AI agents a standardized interface for performing Pokémon damage calculations using the `@smogon/calc` package.
 
+<a href="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-vgc-calc-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-vgc-calc-mcp/badge" alt="Pokémon VGC Damage Calculator Server MCP server" />
+</a>
+
 ## Features
 
 - **MCP-compliant server** with TypeScript and the official MCP SDK


### PR DESCRIPTION
This PR adds a badge for the [Pokémon VGC Damage Calculator MCP Server](https://glama.ai/mcp/servers/@jpbullalayao/pokemon-vgc-calc-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-vgc-calc-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jpbullalayao/pokemon-vgc-calc-mcp/badge" alt="Pokémon VGC Damage Calculator Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.